### PR TITLE
Improve skip time interval detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typescript-aniskip-extension",
   "extensionName": "Aniskip",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "An extension which gives the option to skip anime opening and endings on various streaming sites",
   "main": "content_script.ts",
   "repository": "https://github.com/lexesjan/typescript-aniskip-extension",

--- a/src/components/Menus/SubmitMenu/index.tsx
+++ b/src/components/Menus/SubmitMenu/index.tsx
@@ -14,6 +14,7 @@ import MenuButton from './Button';
 import Input from '../../Input';
 import {
   AniskipHttpClientErrorCode,
+  SkipTimeType,
   SkipType,
 } from '../../../types/api/aniskip_types';
 import useAniskipHttpClient from '../../../hooks/use_aniskip_http_client';
@@ -345,16 +346,20 @@ const SubmitMenu = ({ hidden, onSubmit, onClose }: SubmitMenuProps) => {
             <DefaultButton
               className="shadow-sm flex-1 bg-primary bg-opacity-80 border border-gray-300"
               onClick={async () => {
-                const messageType = 'player-add-preview-skip-time';
+                const episodeLength = await browser.runtime.sendMessage({
+                  type: 'player-get-duration',
+                } as Message);
                 browser.runtime.sendMessage({
-                  type: messageType,
+                  type: 'player-add-skip-time',
                   payload: {
                     interval: {
-                      startTime: timeStringToSeconds(startTime),
-                      endTime: timeStringToSeconds(endTime),
+                      start_time: timeStringToSeconds(startTime),
+                      end_time: timeStringToSeconds(endTime),
                     },
-                    skipType,
-                  },
+                    skip_type: 'preview',
+                    skip_id: '',
+                    episode_length: episodeLength,
+                  } as SkipTimeType,
                 } as Message);
               }}
             >

--- a/src/components/Menus/VoteMenu/index.tsx
+++ b/src/components/Menus/VoteMenu/index.tsx
@@ -30,11 +30,8 @@ const VoteMenu = ({
     setFilteredSkipTimes([...skipTimes.filter((skipTime) => skipTime.skip_id)]);
 
     (async () => {
-      const currentSkipTimesVoted = (
-        await browser.storage.local.get({
-          skipTimesVoted: {},
-        })
-      ).skipTimesVoted;
+      const { skipTimesVoted: currentSkipTimesVoted } =
+        await browser.storage.local.get('skipTimesVoted');
       setSkipTimesVoted(currentSkipTimesVoted);
 
       if (skipTimes.length === 0) {
@@ -159,11 +156,8 @@ const VoteMenu = ({
                         return;
                       }
 
-                      const currentSkipTimesVoted = (
-                        await browser.storage.local.get({
-                          skipTimesVoted,
-                        })
-                      ).skipTimesVoted;
+                      const { skipTimesVoted: currentSkipTimesVoted } =
+                        await browser.storage.local.get('skipTimesVoted');
 
                       const updatedSkipTimesVoted = {
                         ...skipTimesVoted,
@@ -202,11 +196,8 @@ const VoteMenu = ({
                         return;
                       }
 
-                      const currentSkipTimesVoted = (
-                        await browser.storage.local.get({
-                          skipTimesVoted,
-                        })
-                      ).skipTimesVoted;
+                      const { skipTimesVoted: currentSkipTimesVoted } =
+                        await browser.storage.local.get('skipTimesVoted');
 
                       const updatedSkipTimesVoted = {
                         ...skipTimesVoted,

--- a/src/components/SkipButton/Button.tsx
+++ b/src/components/SkipButton/Button.tsx
@@ -10,6 +10,7 @@ const Button = ({ skipType, variant, hidden, onClick }: SkipButtonProps) => {
   const skipTypeFullNames = {
     op: 'Opening',
     ed: 'Ending',
+    preview: 'Preview',
   };
 
   const domainName = getDomainName(window.location.hostname);

--- a/src/components/SkipButton/index.tsx
+++ b/src/components/SkipButton/index.tsx
@@ -26,10 +26,10 @@ const SkipButtonContainer = ({
         const offset = videoDuration - episodeLength;
 
         const inInterval = isInInterval(
-          startTime + offset,
+          startTime,
+          endTime,
           currentTime,
-          0,
-          endTime - startTime
+          offset
         );
 
         return (

--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -28,20 +28,20 @@ const getEpisodeInformation = async () => {
  * Adds the opening and ending skip invervals
  */
 const initialiseSkipTimes = async () => {
-  const skipTypes: SkipType[] = ['op', 'ed'];
   const aniskipHttpClient = new AniskipHttpClient();
   const { malId, episodeNumber } = await getEpisodeInformation();
-  const skipTimeOptions = await browser.storage.sync.get(
-    skipTypes.map((type) => `${type}Option`)
-  );
+  const { skipOptions } = await browser.storage.sync.get('skipOptions');
 
   const skipTimeTypes: SkipType[] = [];
-  Object.entries(skipTimeOptions).forEach(([key, value]) => {
-    const skipType = key.replace('Option', '') as SkipType;
+  Object.entries(skipOptions).forEach(([skipType, value]) => {
     if (value !== 'disabled') {
-      skipTimeTypes.push(skipType);
+      skipTimeTypes.push(skipType as SkipType);
     }
   });
+
+  if (skipTimeTypes.length === 0) {
+    return;
+  }
 
   const getSkipTimesResponse = await aniskipHttpClient.getSkipTimes(
     malId,

--- a/src/options/SettingsPage.tsx
+++ b/src/options/SettingsPage.tsx
@@ -8,15 +8,15 @@ const SettingsPage: React.FC = () => {
   const [edOption, setEdOption] = useState<SkipOptionType>('manual-skip');
 
   const handleOpeningOptionChange = (skipOption: SkipOptionType) => {
-    browser.storage.sync.set({ opOption: skipOption });
+    browser.storage.sync.set({ skipOptions: { op: skipOption, ed: edOption } });
     setOpOption(skipOption);
   };
   const handleEndingOptionChange = (skipOption: SkipOptionType) => {
-    browser.storage.sync.set({ edOption: skipOption });
+    browser.storage.sync.set({ skipOptions: { op: opOption, ed: skipOption } });
     setEdOption(skipOption);
   };
 
-  const skipOptions = [
+  const dropdownOptions = [
     {
       value: 'disabled',
       label: 'Disabled',
@@ -33,15 +33,11 @@ const SettingsPage: React.FC = () => {
 
   useEffect(() => {
     (async () => {
-      const { opOption: opOptionRetrieved, edOption: edOptionRetrieved } =
-        await browser.storage.sync.get({
-          opOption: 'manual-skip',
-          edOption: 'manual-skip',
-        });
-      setOpOption(opOptionRetrieved);
-      setEdOption(edOptionRetrieved);
+      const { skipOptions } = await browser.storage.sync.get('skipOptions');
+      setOpOption(skipOptions.op);
+      setEdOption(skipOptions.ed);
     })();
-  }, [setOpOption, setEdOption]);
+  }, []);
 
   return (
     <div className="sm:border sm:rounded-md border-gray-300 px-8 pt-8 pb-12 sm:bg-white">
@@ -56,7 +52,7 @@ const SettingsPage: React.FC = () => {
           className="text-sm w-full"
           value={opOption}
           onChange={handleOpeningOptionChange}
-          options={skipOptions}
+          options={dropdownOptions}
         />
         <div className="text-xs text-gray-600 uppercase font-bold">
           Ending default action
@@ -65,7 +61,7 @@ const SettingsPage: React.FC = () => {
           className="text-sm w-full"
           value={edOption}
           onChange={handleEndingOptionChange}
-          options={skipOptions}
+          options={dropdownOptions}
         />
       </div>
     </div>

--- a/src/pages/base_page.ts
+++ b/src/pages/base_page.ts
@@ -82,8 +82,8 @@ abstract class BasePage implements Page {
     if (!identifier) {
       return 0;
     }
-    this.malId = (await BasePage.getMalIdCached(identifier)) || 0;
 
+    this.malId = await BasePage.getMalIdCached(identifier);
     if (this.malId > 0) {
       return this.malId;
     }
@@ -102,11 +102,9 @@ abstract class BasePage implements Page {
     }
 
     // Cache MAL id
-    const { malIdCache: updatedMalIdCache } = await browser.storage.local.get({
-      malIdCache: {},
-    });
-    updatedMalIdCache[identifier] = this.malId;
-    browser.storage.local.set({ malIdCache: updatedMalIdCache });
+    const { malIdCache } = await browser.storage.local.get('malIdCache');
+    malIdCache[identifier] = this.malId;
+    browser.storage.local.set({ malIdCache });
 
     return this.malId;
   }
@@ -159,9 +157,7 @@ abstract class BasePage implements Page {
    * @param identifier Provider anime identifier
    */
   static async getMalIdCached(identifier: string): Promise<number> {
-    const { malIdCache } = await browser.storage.local.get({
-      malIdCache: {},
-    });
+    const { malIdCache } = await browser.storage.local.get('malIdCache');
 
     return malIdCache[identifier] || 0;
   }

--- a/src/pages/base_page.ts
+++ b/src/pages/base_page.ts
@@ -118,11 +118,7 @@ abstract class BasePage implements Page {
     const sanitisedTitle = title.replace(/\(.*\)/, '').trim();
 
     const searchResponse = await anilistHttpClient.search(sanitisedTitle);
-    const {
-      data: {
-        Page: { media: searchResults },
-      },
-    } = searchResponse;
+    const searchResults = searchResponse.data.Page.media;
 
     let closest = 0;
     let bestSimilarity = 0;

--- a/src/player_script.scss
+++ b/src/player_script.scss
@@ -93,7 +93,6 @@ form {
 
   &-button {
     &--jw {
-      right: 2em;
       bottom: 6em;
 
       &--fullscreen {
@@ -142,7 +141,6 @@ form {
     bottom: 6em;
     @media (min-width: $md) {
       bottom: 10em;
-      right: 0.5em;
     }
     &--fullscreen {
       @media (min-width: $xl) {

--- a/src/player_script.ts
+++ b/src/player_script.ts
@@ -1,7 +1,7 @@
 import { browser } from 'webextension-polyfill-ts';
 
 import { Message } from './types/message_type';
-import { SkipTimeType, SkipType } from './types/api/aniskip_types';
+import { SkipTimeType } from './types/api/aniskip_types';
 import PlayerFactory from './players/player_factory';
 
 const player = PlayerFactory.getPlayer(window.location.hostname);
@@ -37,20 +37,6 @@ const messageHandler = (message: Message) => {
     }
     case 'player-set-current-time': {
       player.setCurrentTime(message.payload);
-      break;
-    }
-    case 'player-add-preview-skip-time': {
-      const { payload } = message;
-      const skipTime: SkipTimeType = {
-        interval: {
-          start_time: payload.interval.startTime as number,
-          end_time: payload.interval.endTime as number,
-        },
-        skip_type: payload.skipType as SkipType,
-        skip_id: '',
-        episode_length: player.getDuration(),
-      };
-      player.addPreviewSkipTime(skipTime);
       break;
     }
     case 'player-play': {

--- a/src/player_script.ts
+++ b/src/player_script.ts
@@ -88,7 +88,7 @@ new MutationObserver(() => {
       if (target.duration > 60) {
         player.setVideoElement(target);
         player.initialise();
-        player.ready();
+        player.onReady();
       }
     };
   }

--- a/src/players/base_player.ts
+++ b/src/players/base_player.ts
@@ -395,12 +395,13 @@ abstract class BasePlayer implements Player {
     }
 
     this.scheduledSkipTime = setTimeout(() => {
+      this.setCurrentTime(endTime + offset);
+
       if (skipType === 'preview') {
         this.skipTimes = this.skipTimes.filter(
           ({ skip_type: currentSkipType }) => currentSkipType !== 'preview'
         );
       }
-      this.setCurrentTime(endTime + offset);
     }, timeUntilSkipTime * 1000);
   }
 

--- a/src/players/base_player.ts
+++ b/src/players/base_player.ts
@@ -311,9 +311,13 @@ abstract class BasePlayer implements Player {
     );
   }
 
-  ready() {
+  onReady() {
     if (this.videoElement && this.getVideoControlsContainer()) {
       this.isReady = true;
+      this.videoElement.addEventListener('timeupdate', (event) => {
+        const { currentTime } = event.currentTarget as HTMLVideoElement;
+        this.skipButtonRenderer.setCurrentTime(currentTime);
+      });
       browser.runtime.sendMessage({ type: 'player-ready' } as Message);
     }
   }
@@ -389,8 +393,6 @@ abstract class BasePlayer implements Player {
         if (!manual && inInterval) {
           this.setCurrentTime(endTime + offset);
         }
-
-        this.skipButtonRenderer.setCurrentTime(currentTime);
       });
 
     return timeUpdateEventListener;

--- a/src/players/base_player.ts
+++ b/src/players/base_player.ts
@@ -395,7 +395,7 @@ abstract class BasePlayer implements Player {
     }
 
     this.scheduledSkipTime = setTimeout(() => {
-      if (skipType) {
+      if (skipType === 'preview') {
         this.skipTimes = this.skipTimes.filter(
           ({ skip_type: currentSkipType }) => currentSkipType !== 'preview'
         );

--- a/src/players/base_player.ts
+++ b/src/players/base_player.ts
@@ -30,7 +30,7 @@ abstract class BasePlayer implements Player {
 
   videoElement: HTMLVideoElement | null;
 
-  timeUpdateEventListeners: Record<string, (event: Event) => void>;
+  timeUpdateEventListeners: Record<string, EventListener>;
 
   constructor(document: Document, metadata: Metadata) {
     this.document = document;

--- a/src/players/base_player.ts
+++ b/src/players/base_player.ts
@@ -139,8 +139,8 @@ abstract class BasePlayer implements Player {
 
     const skipType = skipTime.skip_type;
     const skipOption: SkipOptionType = (
-      await browser.storage.sync.get(`${skipType}Option`)
-    )[`${skipType}Option`];
+      await browser.storage.sync.get('skipOptions')
+    ).skipOptions[skipType];
     const manual = skipOption === 'manual-skip';
 
     this.skipTimeIndicatorsRenderer.addSkipTimeIndicator(skipTime);

--- a/src/players/base_player.ts
+++ b/src/players/base_player.ts
@@ -97,22 +97,15 @@ abstract class BasePlayer implements Player {
     );
 
     const previewSkipHandler = (event: Event) => {
-      const margin = 0;
       const video = event.currentTarget as HTMLVideoElement;
-      const checkIntervalLength = 5;
       const { interval, episode_length: episodeLength } = skipTime;
       const { start_time: startTime, end_time: endTime } = interval;
       const offset = video.duration - episodeLength;
       const { currentTime } = video;
-      const inInterval = isInInterval(
-        startTime,
-        currentTime,
-        margin,
-        checkIntervalLength
-      );
+      const inInterval = isInInterval(startTime, startTime + 1, currentTime);
 
       if (inInterval) {
-        this.setCurrentTime(endTime + offset + margin);
+        this.setCurrentTime(endTime + offset);
         video.removeEventListener('timeupdate', previewSkipHandler);
         Object.values(this.timeUpdateEventListeners).forEach(
           (functionReference) => {
@@ -381,21 +374,20 @@ abstract class BasePlayer implements Player {
     const timeUpdateEventListener =
       this.timeUpdateEventListeners[skipTimeString] ||
       (this.timeUpdateEventListeners[skipTimeString] = (event: Event) => {
-        const margin = 0;
         const video = event.currentTarget as HTMLVideoElement;
         const { interval, episode_length: episodeLength } = skipTime;
         const { start_time: startTime, end_time: endTime } = interval;
         const offset = video.duration - episodeLength;
         const { currentTime } = video;
         const inInterval = isInInterval(
-          startTime + offset,
+          startTime,
+          startTime + 1,
           currentTime,
-          margin,
-          1
+          offset
         );
 
         if (!manual && inInterval) {
-          this.setCurrentTime(endTime + offset + margin);
+          this.setCurrentTime(endTime + offset);
         }
 
         this.skipButtonRenderer.setCurrentTime(currentTime);

--- a/src/players/jw/metadata.json
+++ b/src/players/jw/metadata.json
@@ -5,17 +5,18 @@
   "injectMenusButtonsReferenceNodeSelectorString": "Settings",
   "seekBarContainerSelectorString": "Seek",
   "player_urls": [
-    "*://gogo-play.net/*",
-    "*://gogo-play.tv/*",
-    "*://streamsb.net/*",
+    "*://*.streamhd.cc/*",
     "*://cloud9.to/*",
     "*://fcdn.stream/*",
+    "*://gogo-play.net/*",
+    "*://gogo-play.tv/*",
+    "*://kimanime.ru/AnimeIframe/*",
     "*://mcloud.to/*",
     "*://mcloud2.to/*",
-    "*://vidstream.pro/e/*",
-    "*://*.streamhd.cc/*",
     "*://sbembed.com/*",
-    "*://kimanime.ru/AnimeIframe/*",
-    "*://sbvideo.net/*"
+    "*://sbvideo.net/*",
+    "*://streamani.net/*",
+    "*://streamsb.net/*",
+    "*://vidstream.pro/e/*"
   ]
 }

--- a/src/players/player_factory.ts
+++ b/src/players/player_factory.ts
@@ -31,6 +31,7 @@ class PlayerFactory {
       case 'mcloud2':
       case 'sbembed':
       case 'sbvideo':
+      case 'streamani':
       case 'streamhd':
       case 'streamsb':
       case 'vidstream':

--- a/src/players/plyr/metadata.json
+++ b/src/players/plyr/metadata.json
@@ -5,11 +5,11 @@
   "seekBarContainerSelectorString": "plyr__progress",
   "injectMenusButtonsReferenceNodeSelectorString": "plyr__controls__item plyr__menu",
   "player_urls": [
-    "*://aniwatch.me/*",
-    "*://streamtape.com/*",
-    "*://animixplay.to/v*/*",
-    "*://animixplay.to/api/*",
     "*://akaneshinjou.github.io/play/*",
-    "*://kwik.cx/e/*"
+    "*://animixplay.to/api/*",
+    "*://animixplay.to/v*/*",
+    "*://aniwatch.me/*",
+    "*://kwik.cx/e/*",
+    "*://streamtape.com/*"
   ]
 }

--- a/src/players/twistmoe/index.ts
+++ b/src/players/twistmoe/index.ts
@@ -7,7 +7,7 @@ class Twistmoe extends BasePlayer {
   }
 
   getVideoContainer() {
-    return super.getContainerHelper(metadata.videoContainerSelectorString, 0);
+    return super.getContainerHelper(metadata.videoContainerSelectorString);
   }
 
   getVideoControlsContainer() {

--- a/src/players/videojs/metadata.json
+++ b/src/players/videojs/metadata.json
@@ -5,9 +5,9 @@
   "injectMenusButtonsReferenceNodeSelectorString": "vjs-fullscreen-control",
   "seekBarContainerSelectorString": "vjs-progress-holder vjs-slider",
   "player_urls": [
-    "*://www.mp4upload.com/embed-*",
-    "*://mixdrop.co/e/*",
     "*://4anime.to/*",
-    "*://mp4.sh/*"
+    "*://mixdrop.co/e/*",
+    "*://mp4.sh/*",
+    "*://www.mp4upload.com/embed-*"
   ]
 }

--- a/src/types/api/aniskip_types.ts
+++ b/src/types/api/aniskip_types.ts
@@ -1,4 +1,4 @@
-export type SkipType = 'op' | 'ed';
+export type SkipType = 'op' | 'ed' | 'preview';
 
 export interface SkipTimeType {
   interval: {

--- a/src/types/background_script_types.ts
+++ b/src/types/background_script_types.ts
@@ -3,8 +3,10 @@ import { SkipOptionType } from './skip_option_type';
 
 export interface DefaultOptionsType {
   userId: string;
-  opOption: SkipOptionType;
-  edOption: SkipOptionType;
+  skipOptions: {
+    op: SkipOptionType;
+    ed: SkipOptionType;
+  };
 }
 
 export interface LocalDefaultOptionsType {

--- a/src/types/background_script_types.ts
+++ b/src/types/background_script_types.ts
@@ -1,12 +1,9 @@
 import { VoteType } from './api/aniskip_types';
-import { SkipOptionType } from './skip_option_type';
+import { SkipOptionsType } from './skip_option_type';
 
 export interface DefaultOptionsType {
   userId: string;
-  skipOptions: {
-    op: SkipOptionType;
-    ed: SkipOptionType;
-  };
+  skipOptions: SkipOptionsType;
 }
 
 export interface LocalDefaultOptionsType {

--- a/src/types/player_types.ts
+++ b/src/types/player_types.ts
@@ -17,12 +17,6 @@ export interface Player {
   isReady: boolean;
 
   /**
-   * Adds a skip time which will run once for preview
-   * @param skipTime Skip time to preview
-   */
-  addPreviewSkipTime(skipTime: SkipTimeType): void;
-
-  /**
    * Adds a skip time into the player
    * @param skipTime Skip time to add
    * @param manual True if the user has to click skip opening / ending button, false if auto skip

--- a/src/types/player_types.ts
+++ b/src/types/player_types.ts
@@ -66,7 +66,8 @@ export interface Player {
   reset(): void;
 
   /**
-   * Notify the content script that the player is ready for comminucation
+   * Notify the content script that the player is ready for comminucation and
+   * initialise event listeners
    */
   onReady(): void;
 

--- a/src/types/player_types.ts
+++ b/src/types/player_types.ts
@@ -68,7 +68,7 @@ export interface Player {
   /**
    * Notify the content script that the player is ready for comminucation
    */
-  ready(): void;
+  onReady(): void;
 
   /**
    * Sets the video element current time to the input time

--- a/src/types/skip_option_type.ts
+++ b/src/types/skip_option_type.ts
@@ -1,1 +1,6 @@
 export type SkipOptionType = 'disabled' | 'auto-skip' | 'manual-skip';
+
+export interface SkipOptionsType {
+  op: SkipOptionType;
+  ed: SkipOptionType;
+}

--- a/src/utils/string_utils.ts
+++ b/src/utils/string_utils.ts
@@ -47,10 +47,17 @@ export const secondsToTimeString = (
   const minutes = Math.floor(remainingSeconds / 60);
   const minutesFormatted = minutes.toString().padStart(hours ? 2 : 1, '0');
 
+  let secondsZeroPadding = decimalPlaces + 3;
+  if (decimalPlaces === 0) {
+    secondsZeroPadding = 2;
+    // ensure that toFixed does not round
+    remainingSeconds = Math.floor(remainingSeconds);
+  }
+
   remainingSeconds %= 60;
   const secondsFormated = remainingSeconds
     .toFixed(decimalPlaces)
-    .padStart(decimalPlaces + (decimalPlaces === 0 ? 2 : 3), '0');
+    .padStart(secondsZeroPadding, '0');
 
   return `${
     hours ? `${hoursFormatted}:` : ''

--- a/src/utils/time_utils.ts
+++ b/src/utils/time_utils.ts
@@ -1,18 +1,20 @@
 /**
  * Checks if the current time is within an interval
  * @param startTime Start time of the interval
+ * @param endTime End time of the interval
  * @param currentTime Current time to check
+ * @param offset Offset of the video provider
  * @param margin Margin of error
- * @param checkIntervalLength Interval length
  */
 const isInInterval = (
   startTime: number,
+  endTime: number,
   currentTime: number,
-  margin: number,
-  checkIntervalLength: number
+  offset: number = 0,
+  margin: number = 0
 ): boolean =>
   currentTime >= 0 &&
-  currentTime >= startTime + margin &&
-  currentTime <= startTime - margin + checkIntervalLength;
+  startTime + margin + offset <= currentTime &&
+  currentTime <= endTime - margin + offset;
 
 export default isInInterval;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,8 +11,8 @@ module.exports = {
   darkMode: false, // or 'media' or 'class'
   theme: {
     colors: {
-      primary: colors.amber[500],
       ...colors,
+      primary: colors.amber[500],
     },
     fontSize: {
       xs: '0.75em',


### PR DESCRIPTION
## Purpose

Currently the accuracy of the auto skip has a margin of error of around +- 250ms. Closes #51, closes #52.

## Proposed Change

We can use `setTimeout` to reduce this to around +- 10ms.

## Checklist

- [x] Refactor skip time interval detection to use `setTimeout`

## Additional

Out of scope changes:
- [x] Add `jw` player domain
- [x] Vote and skip menu placement changes for `jw` player
- [x] Fix vote menu timestamp bug
