### PR TITLE
Fix movie episode number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typescript-aniskip-extension",
   "extensionName": "Aniskip",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "An extension which gives the option to skip anime opening and endings on various streaming sites",
   "main": "content_script.ts",
   "repository": "https://github.com/lexesjan/typescript-aniskip-extension",

--- a/src/pages/crunchyroll/index.ts
+++ b/src/pages/crunchyroll/index.ts
@@ -15,16 +15,16 @@ class Crunchyroll extends BasePage {
       return episodeNumber;
     }
 
-    return 0;
+    return 1;
   }
 
   getTitle() {
-    const title = this.document
-      .querySelector('[name="title"]')
-      ?.getAttribute('content')
-      ?.split(' Episode')[0];
+    const metadata = JSON.parse(
+      this.document.querySelector('[type="application/ld+json"]')?.innerHTML ||
+        '{}'
+    );
 
-    return title || '';
+    return metadata.partOfSeason.name || '';
   }
 }
 

--- a/src/pages/fouranime/index.ts
+++ b/src/pages/fouranime/index.ts
@@ -18,7 +18,7 @@ class FourAnime extends BasePage {
       return episodeNumber;
     }
 
-    return 0;
+    return 1;
   }
 }
 

--- a/src/pages/nineanime/index.ts
+++ b/src/pages/nineanime/index.ts
@@ -8,7 +8,13 @@ class Nineanime extends BasePage {
 
   getRawEpisodeNumber() {
     const cleansedPath = this.pathname.replace(/.*\./, '');
-    const episodeNumber = parseInt(cleansedPath.split(/\/ep-/)[1], 10);
+    const episodeString = cleansedPath.split(/\/ep-/)[1];
+
+    if (episodeString === 'full') {
+      return 1;
+    }
+
+    const episodeNumber = parseInt(episodeString, 10);
 
     return episodeNumber;
   }

--- a/src/player_script.scss
+++ b/src/player_script.scss
@@ -49,6 +49,12 @@ form {
         height: $videojs-button-size;
       }
 
+      &--vidstream,
+      &--vidstreamz {
+        margin-left: -5px;
+        margin-right: -5px;
+      }
+
       &--twistmoe {
         pointer-events: all;
         margin-top: 2px;

--- a/src/players/jw/metadata.json
+++ b/src/players/jw/metadata.json
@@ -17,6 +17,7 @@
     "*://sbvideo.net/*",
     "*://streamani.net/*",
     "*://streamsb.net/*",
-    "*://vidstream.pro/e/*"
+    "*://vidstream.pro/e/*",
+    "*://vidstreamz.online/embed/*"
   ]
 }

--- a/src/players/player_factory.ts
+++ b/src/players/player_factory.ts
@@ -35,6 +35,7 @@ class PlayerFactory {
       case 'streamhd':
       case 'streamsb':
       case 'vidstream':
+      case 'vidstreamz':
         return new Jw(document);
       case 'dood':
         return new Doodstream(document);


### PR DESCRIPTION
## Purpose

Some supported websites do not correctly set the episode number when parsing an anime movie. Closes #55.

## Proposed Change

Default to episode 1 when episode number cannot be parsed.

## Checklist

- [x] Default to episode 1 in some supported websites

## Additional

Out of scope changes:
- [x] Add one domain for `jw` player
