### PR TITLE
Add mobile crunchyroll support

### DIFF
--- a/src/components/Menus/Buttons.tsx
+++ b/src/components/Menus/Buttons.tsx
@@ -4,14 +4,14 @@ import SubmitMenu from './SubmitMenu';
 import VoteMenu from './VoteMenu';
 import { MenusButtonsProps } from '../../types/components/menus_types';
 import { getDomainName } from '../../utils/string_utils';
-import useFullscreen from '../../hooks/use_fullscreen';
+import useFullscreenState from '../../hooks/use_fullscreen_state';
 
 const Buttons = ({
   variant,
   submitMenuButtonProps,
   voteMenuButtonProps,
 }: MenusButtonsProps) => {
-  const { isFullscreen } = useFullscreen();
+  const { isFullscreen } = useFullscreenState();
 
   const domainName = getDomainName(window.location.hostname);
 

--- a/src/components/Menus/index.tsx
+++ b/src/components/Menus/index.tsx
@@ -22,7 +22,11 @@ const MenuContainer = ({ variant, children }: MenuContainerProps) => {
         isFullscreen
           ? `menus--${variant}--fullscreen menus--${domainName}--fullscreen`
           : ''
-      } ${isMobile ? `menus--${variant}--mobile` : ''}`}
+      } ${
+        isMobile
+          ? `menus--mobile menus--${variant}--mobile menus--${domainName}--mobile`
+          : ''
+      }`}
     >
       {children}
     </div>

--- a/src/components/Menus/index.tsx
+++ b/src/components/Menus/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import useFullscreen from '../../hooks/use_fullscreen';
+import useFullscreenState from '../../hooks/use_fullscreen_state';
+import useMobileState from '../../hooks/use_mobile_state';
 
 import {
   MenuContainerProps,
@@ -11,7 +12,8 @@ import SubmitMenu from './SubmitMenu';
 import VoteMenu from './VoteMenu';
 
 const MenuContainer = ({ variant, children }: MenuContainerProps) => {
-  const { isFullscreen } = useFullscreen();
+  const { isFullscreen } = useFullscreenState();
+  const { isMobile } = useMobileState();
   const domainName = getDomainName(window.location.hostname);
 
   return (
@@ -20,7 +22,7 @@ const MenuContainer = ({ variant, children }: MenuContainerProps) => {
         isFullscreen
           ? `menus--${variant}--fullscreen menus--${domainName}--fullscreen`
           : ''
-      }`}
+      } ${isMobile ? `menus--${variant}--mobile` : ''}`}
     >
       {children}
     </div>

--- a/src/components/SkipButton/Button.tsx
+++ b/src/components/SkipButton/Button.tsx
@@ -23,7 +23,11 @@ const Button = ({ skipType, variant, hidden, onClick }: SkipButtonProps) => {
         isFullscreen
           ? `skip-button--${variant}--fullscreen skip-button--${domainName}--fullscreen`
           : ''
-      } ${isMobile ? `skip-button--${variant}--mobile` : ''}`}
+      } ${
+        isMobile
+          ? `skip-button--mobile skip-button--${variant}--mobile skip-button--${domainName}--mobile`
+          : ''
+      }`}
     >
       <DefaultButton
         className={`transition-opacity font-sans whitespace-nowrap text-white bg-trueGray-800 bg-opacity-80 py-3 border border-gray-300 font-bold uppercase ${

--- a/src/components/SkipButton/Button.tsx
+++ b/src/components/SkipButton/Button.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import useFullscreen from '../../hooks/use_fullscreen';
+import useFullscreenState from '../../hooks/use_fullscreen_state';
+import useMobileState from '../../hooks/use_mobile_state';
 import { SkipButtonProps } from '../../types/components/skip_time_button_types';
 import { getDomainName } from '../../utils/string_utils';
 import DefaultButton from '../Button';
 
 const Button = ({ skipType, variant, hidden, onClick }: SkipButtonProps) => {
-  const { isFullscreen } = useFullscreen();
+  const { isFullscreen } = useFullscreenState();
+  const { isMobile } = useMobileState();
 
   const skipTypeFullNames = {
     op: 'Opening',
@@ -21,7 +23,7 @@ const Button = ({ skipType, variant, hidden, onClick }: SkipButtonProps) => {
         isFullscreen
           ? `skip-button--${variant}--fullscreen skip-button--${domainName}--fullscreen`
           : ''
-      }`}
+      } ${isMobile ? `skip-button--${variant}--mobile` : ''}`}
     >
       <DefaultButton
         className={`transition-opacity font-sans whitespace-nowrap text-white bg-trueGray-800 bg-opacity-80 py-3 border border-gray-300 font-bold uppercase ${

--- a/src/hooks/use_fullscreen_state.ts
+++ b/src/hooks/use_fullscreen_state.ts
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 /**
  * Returns if the browser is in full screen
  */
-const useFullscreen = () => {
+const useFullscreenState = () => {
   const [isFullscreen, setIsFullscreen] = useState(false);
 
   useEffect(() => {
@@ -19,4 +19,4 @@ const useFullscreen = () => {
   return { isFullscreen };
 };
 
-export default useFullscreen;
+export default useFullscreenState;

--- a/src/hooks/use_mobile_state.ts
+++ b/src/hooks/use_mobile_state.ts
@@ -1,0 +1,14 @@
+import { useState } from 'react';
+
+import isMobileTest from '../utils/responsive_utils';
+
+/**
+ * Returns if the browser is a mobile browser
+ */
+const useMobileState = () => {
+  const [isMobile] = useState(isMobileTest());
+
+  return { isMobile };
+};
+
+export default useMobileState;

--- a/src/player_script.scss
+++ b/src/player_script.scss
@@ -98,8 +98,13 @@ form {
   }
 
   &-button {
+    &--mobile {
+      right: 1.25em;
+      bottom: 4em;
+    }
+
     &--crunchyroll--mobile {
-      right: 1.5em;
+      right: 0px;
     }
 
     &--jw {
@@ -130,6 +135,10 @@ form {
       @media (min-width: 901px) {
         bottom: 4em;
       }
+
+      &--mobile {
+        bottom: 5em;
+      }
     }
 
     &--streamtape,
@@ -140,29 +149,40 @@ form {
 }
 
 .menus {
+  &--mobile {
+    left: 1.25em;
+    right: 0px;
+    bottom: 4em;
+  }
+
   &--crunchyroll {
     bottom: 7em;
+
     @media (min-width: $md) {
       bottom: 11em;
     }
 
     &--mobile {
       bottom: 4em;
-      right: 0px;
-      left: 1.25em;
     }
   }
 
   &--jw {
     bottom: 6em;
+
     @media (min-width: $md) {
       bottom: 10em;
     }
+
     &--fullscreen {
       @media (min-width: $xl) {
         right: 3em;
         bottom: 13em;
       }
+    }
+
+    &--mobile {
+      bottom: 6em;
     }
   }
 
@@ -176,26 +196,42 @@ form {
   &--doodstream {
     right: 2.5em;
     bottom: 9em;
+
     @media (min-width: $md) {
       bottom: 13em;
+    }
+
+    &--mobile {
+      bottom: 9em;
     }
   }
 
   &--4anime {
     bottom: 6em;
+
     @media (min-width: $md) {
       bottom: 10em;
     }
+
     @media (min-width: 901px) {
       bottom: 8em;
+    }
+
+    &--mobile {
+      bottom: 5em;
     }
   }
 
   &--streamtape,
   &--mixdrop {
     bottom: 5em;
+
     @media (min-width: $md) {
       bottom: 9em;
+    }
+
+    &--mobile {
+      bottom: 5em;
     }
   }
 

--- a/src/player_script.scss
+++ b/src/player_script.scss
@@ -98,6 +98,10 @@ form {
   }
 
   &-button {
+    &--crunchyroll--mobile {
+      right: 1.5em;
+    }
+
     &--jw {
       bottom: 6em;
 
@@ -140,6 +144,12 @@ form {
     bottom: 7em;
     @media (min-width: $md) {
       bottom: 11em;
+    }
+
+    &--mobile {
+      bottom: 4em;
+      right: 0px;
+      left: 1.25em;
     }
   }
 

--- a/src/players/crunchyroll/index.ts
+++ b/src/players/crunchyroll/index.ts
@@ -1,3 +1,4 @@
+import isMobile from '../../utils/responsive_utils';
 import BasePlayer from '../base_player';
 import metadata from './metadata.json';
 
@@ -7,6 +8,12 @@ class Crunchyroll extends BasePlayer {
   }
 
   getSeekBarContainer() {
+    if (isMobile()) {
+      return super.getContainerHelper(
+        'css-1dbjc4n r-13awgt0 r-18u37iz r-1udh08x r-13qz1uu'
+      );
+    }
+
     return super.getContainerHelper(metadata.seekBarContainerSelectorString, 1);
   }
 

--- a/src/players/crunchyroll/index.ts
+++ b/src/players/crunchyroll/index.ts
@@ -7,10 +7,29 @@ class Crunchyroll extends BasePlayer {
     super(document, metadata);
   }
 
+  injectSkipButtons() {
+    if (isMobile()) {
+      const seekBarContainer = this.getSeekBarContainer();
+
+      if (
+        seekBarContainer &&
+        !this.document.getElementById(this.skipButtonRenderer.id)
+      ) {
+        seekBarContainer.parentElement?.appendChild(
+          this.skipButtonRenderer.shadowRootContainer
+        );
+      }
+
+      return;
+    }
+
+    super.injectSkipButtons();
+  }
+
   getSeekBarContainer() {
     if (isMobile()) {
       return super.getContainerHelper(
-        'css-1dbjc4n r-13awgt0 r-18u37iz r-1udh08x r-13qz1uu'
+        metadata.seekBarContainerSelectorStringMobile
       );
     }
 

--- a/src/players/crunchyroll/metadata.json
+++ b/src/players/crunchyroll/metadata.json
@@ -4,5 +4,6 @@
   "videoControlsContainerSelectorString": "velocity-controls-package",
   "injectMenusButtonsReferenceNodeSelectorString": "settingsControl",
   "seekBarContainerSelectorString": "r-13awgt0 r-18u37iz r-1udh08x r-13qz1uu css-1dbjc4n",
+  "seekBarContainerSelectorStringMobile": "css-1dbjc4n r-13awgt0 r-18u37iz r-1udh08x r-13qz1uu",
   "player_urls": ["*://static.crunchyroll.com/*"]
 }

--- a/src/types/player_types.ts
+++ b/src/types/player_types.ts
@@ -6,6 +6,7 @@ export interface Metadata {
   videoControlsContainerSelectorString: string;
   injectMenusButtonsReferenceNodeSelectorString: string;
   seekBarContainerSelectorString: string;
+  seekBarContainerSelectorStringMobile?: string;
   player_urls: string[];
 }
 

--- a/src/utils/responsive_utils.ts
+++ b/src/utils/responsive_utils.ts
@@ -1,0 +1,9 @@
+/**
+ * Returns true if a mobile browser is detected
+ */
+const isMobile = () =>
+  /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+    navigator.userAgent
+  );
+
+export default isMobile;


### PR DESCRIPTION
## Purpose

Currently when watching on mobile, injecting into the Crunchyroll player does not work properly. Closes #61.

## Proposed Change

Add check for mobile and inject using the correct selector strings.

## Checklist

- [x] Add mobile browser detection
- [x] Use mobile specific strings to inject into the Crunchyroll player

## Additional

Out of scope changes:

- [x] Fix responsiveness on larger phones e.g. Pixel 2 XL, Samsung Galaxy S21
