### PR TITLE
Add new ply player url

### DIFF
--- a/src/players/plyr/metadata.json
+++ b/src/players/plyr/metadata.json
@@ -6,6 +6,7 @@
   "injectMenusButtonsReferenceNodeSelectorString": "plyr__controls__item plyr__menu",
   "player_urls": [
     "*://akaneshinjou.github.io/play/*",
+    "*://akane-shinjou.github.io/*",
     "*://animixplay.to/api/*",
     "*://animixplay.to/v*/*",
     "*://aniwatch.me/*",


### PR DESCRIPTION
## Purpose

The script was not picking up video players as a new source was used.

## Proposed Change

Adds new source URL.

## Checklist

- [x] Adds new source.
- [x] Manual test with `yarn start:prod:chrome`

