### PR TITLE
Fix auto update of yarn version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,5 @@ jobs:
         uses: actions/checkout@v2
 
       # run tests
-      - run: yarn set version berry
       - run: yarn install
       - run: yarn lint


### PR DESCRIPTION
## Purpose

The CI pipeline is non-deterministic.

## Proposed Change

Don't update yarn version when running the pipeline.

## Checklist

- [x] Remove `yarn set version berry`
