### PR TITLE
Switch open overlay keybind to Ctrl+Shift+F

### DIFF
--- a/src/scripts/background/types.ts
+++ b/src/scripts/background/types.ts
@@ -54,7 +54,7 @@ export type Keybinds = {
 };
 
 export const DEFAULT_KEYBINDS: Keybinds = {
-  'open-anime-search-overlay': 'Ctrl+Space',
+  'open-anime-search-overlay': 'Ctrl+Shift+F',
   'increase-current-time': 'l',
   'increase-current-time-large': 'Shift+L',
   'decrease-current-time': 'j',


### PR DESCRIPTION
## Purpose

`Ctrl+Space` keybind is used in Opera.

## Proposed Change

Switch the anime search keybind to `Ctrl+Shift+F`.

## Checklist

- [x] Change default keybind
