### PR TITLE
Fix title language settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typescript-aniskip-extension",
   "extensionName": "Aniskip",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "An extension which gives the option to skip anime opening and endings on various streaming sites",
   "repository": "https://github.com/lexesjan/typescript-aniskip-extension",
   "contributors": [

--- a/src/components/AnimeSearchModal/AnimeSearchModal.tsx
+++ b/src/components/AnimeSearchModal/AnimeSearchModal.tsx
@@ -167,12 +167,12 @@ export function AnimeSearchModal({
         format: media.format,
         seasonYear: media.seasonYear,
         malId: media.idMal,
-        title: media.title[animeTitleLanguage] ?? media.title.romaji,
+        title: media.title[animeTitleLanguage] || media.title.romaji,
       };
 
       setAnimeDetected(searchResult);
     })();
-  }, []);
+  }, [animeTitleLanguage]);
 
   return (
     <div

--- a/src/components/SubmitMenu/SubmitMenu.tsx
+++ b/src/components/SubmitMenu/SubmitMenu.tsx
@@ -541,9 +541,9 @@ export function SubmitMenu(): JSX.Element {
             </DefaultButton>
             <div className="flex justify-between bg-primary bg-opacity-80 border border-gray-300 rounded">
               <DefaultButton
-                title="Seek -0.25s"
+                title={`Seek -${changeCurrentTimeLargeLength}s`}
                 className="group px-3"
-                onClick={onClickSeekTime(-0.25)}
+                onClick={onClickSeekTime(-changeCurrentTimeLargeLength)}
               >
                 <FaBackward
                   className="transition-transform duration-150 transform group-hover:scale-125 group-active:scale-100"
@@ -557,9 +557,9 @@ export function SubmitMenu(): JSX.Element {
                 Now
               </DefaultButton>
               <DefaultButton
-                title="Seek +0.25s"
+                title={`Seek +${changeCurrentTimeLargeLength}s`}
                 className="group px-3"
-                onClick={onClickSeekTime(0.25)}
+                onClick={onClickSeekTime(changeCurrentTimeLargeLength)}
               >
                 <FaForward
                   className="transition-transform duration-150 transform group-hover:scale-125 group-active:scale-100"

--- a/src/options/components/SettingsPage/SettingsPage.tsx
+++ b/src/options/components/SettingsPage/SettingsPage.tsx
@@ -335,6 +335,7 @@ export function SettingsPage(): JSX.Element {
           syncOptions.changeCurrentTimeLargeLength
         )
       );
+      dispatch(setAnimeTitleLanguage(syncOptions.animeTitleLanguage));
       dispatch(setIsSettingsLoaded(true));
     })();
   }, []);


### PR DESCRIPTION
## Purpose

Title language settings were not respected in the anime search overlay.

## Proposed Change

Fix this bug.

## Checklist

- [x] Ensure that the user settings for title language is applied to the search

## Additional

Out of scope changes:

- [x] Fix change current time button not using user settings
