### PR TITLE
Fix auto skip bugs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": ["config:base"],
+  "labels": ["automated update"],
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typescript-aniskip-extension",
   "extensionName": "Aniskip",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "An extension which gives the option to skip anime opening and endings on various streaming sites",
   "repository": "https://github.com/lexesjan/typescript-aniskip-extension",
   "contributors": [

--- a/src/components/SkipButtonContainer/SkipButtonContainer.tsx
+++ b/src/components/SkipButtonContainer/SkipButtonContainer.tsx
@@ -56,25 +56,20 @@ export function SkipButtonContainer(): JSX.Element | null {
     let minimumDistance = Infinity;
 
     skipTimes.forEach((skipTime) => {
-      if (skipTime.skipType === 'preview') {
+      const { skipType } = skipTime;
+      const isManualSkip = skipOptions[skipType] === 'manual-skip';
+
+      if (skipType === 'preview' || isManualSkip) {
         return;
       }
 
-      const { skipType, interval } = skipTime;
+      const { interval } = skipTime;
       const offset = videoDuration - skipTime.episodeLength;
-      const isManualSkip = skipOptions[skipType] === 'manual-skip';
-
       const distance = Math.abs(interval.endTime - currentTime);
 
       if (
-        isManualSkip &&
-        (distance < minimumDistance ||
-          isInInterval(
-            interval.startTime,
-            interval.endTime,
-            currentTime,
-            offset
-          ))
+        distance < minimumDistance ||
+        isInInterval(interval.startTime, interval.endTime, currentTime, offset)
       ) {
         closestSkipTime = skipTime;
         minimumDistance = distance;

--- a/src/components/SkipButtonContainer/SkipButtonContainer.tsx
+++ b/src/components/SkipButtonContainer/SkipButtonContainer.tsx
@@ -57,9 +57,9 @@ export function SkipButtonContainer(): JSX.Element | null {
 
     skipTimes.forEach((skipTime) => {
       const { skipType } = skipTime;
-      const isManualSkip = skipOptions[skipType] === 'manual-skip';
+      const isAutoSkip = skipOptions[skipType] === 'auto-skip';
 
-      if (skipType === 'preview' || isManualSkip) {
+      if (skipType === 'preview' || isAutoSkip) {
         return;
       }
 

--- a/src/components/SkipButtonContainer/SkipButtonContainer.tsx
+++ b/src/components/SkipButtonContainer/SkipButtonContainer.tsx
@@ -67,8 +67,14 @@ export function SkipButtonContainer(): JSX.Element | null {
       const distance = Math.abs(interval.endTime - currentTime);
 
       if (
-        (isManualSkip && distance < minimumDistance) ||
-        isInInterval(interval.startTime, interval.endTime, currentTime, offset)
+        isManualSkip &&
+        (distance < minimumDistance ||
+          isInInterval(
+            interval.startTime,
+            interval.endTime,
+            currentTime,
+            offset
+          ))
       ) {
         closestSkipTime = skipTime;
         minimumDistance = distance;

--- a/src/players/base-player.ts
+++ b/src/players/base-player.ts
@@ -106,6 +106,7 @@ export class BasePlayer implements Player {
     }
 
     const isAutoSkip = this.skipOptions[skipTime.skipType] === 'auto-skip';
+
     if (!isAutoSkip) {
       return;
     }
@@ -115,9 +116,8 @@ export class BasePlayer implements Player {
     const currentTime = this.getCurrentTime();
 
     // Skip time loaded late.
-    if (isInInterval(startTime, endTime, currentTime, offset)) {
+    if (isInInterval(startTime, startTime + 0.25, currentTime)) {
       this.setCurrentTime(endTime + offset);
-      this.play();
     }
   }
 

--- a/src/players/base-player.ts
+++ b/src/players/base-player.ts
@@ -365,11 +365,14 @@ export class BasePlayer implements Player {
     if (this.videoElement && this.getVideoControlsContainer()) {
       this.isReady = true;
 
-      this.videoElement.addEventListener('timeupdate', () => {
+      const listener = (): void => {
         this.scheduleSkipTimes();
         this.skipButtonRenderer.render();
         this.skipTimeIndicatorsRenderer.render();
-      });
+      };
+
+      this.videoElement.addEventListener('timeupdate', listener);
+      this.videoElement.addEventListener('playing', listener);
 
       this.initialiseSkipTimes();
     }

--- a/src/players/base-player.ts
+++ b/src/players/base-player.ts
@@ -180,7 +180,7 @@ export class BasePlayer implements Player {
 
       if (
         isAutoSkip &&
-        currentTime < startTime + offset &&
+        currentTime <= startTime + offset &&
         startTime + offset < earliestStartTime
       ) {
         earliestStartTime = startTime;


### PR DESCRIPTION
## Purpose

When auto skipping is used, the skip button is visible. Auto skipping does not work reliably when it is at the beginning of a video.

## Proposed Change

Fix logic to ensure that only manual skip times show the skip button. Schedule skip times when the video is played.

## Checklist

- [x] Fix skip button logic
- [x] Fix auto skip not working at the start of the video
- [x] Bump version patch

## Additional

Out of scope changes:

- [x] Configure renovate to add labels on PRs
