### PR TITLE
Add auto merging

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "extends": ["config:base"],
   "labels": ["automated update"],
   "automerge": true,
+  "platformAutomerge": true,
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": ["config:base"],
   "labels": ["automated update"],
+  "automerge": true,
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,12 +1,19 @@
 {
   "extends": ["config:base"],
   "labels": ["automated update"],
-  "automerge": true,
-  "platformAutomerge": true,
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],
       "rangeStrategy": "bump"
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "automerge": true
     }
-  ]
+  ],
+  "platformAutomerge": true
 }


### PR DESCRIPTION
## Purpose

It can get tedious to merge multiple depedency update PRs.

## Proposed Change

Add automerging to the renovate config.

## Checklist

- [x] Add auto merging
   - For minor updates
   - For patch updates
- [x] Add `renovate-approve` GitHub app

