### PR TITLE
Fix zoro titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typescript-aniskip-extension",
   "extensionName": "Aniskip",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "An extension which gives the option to skip anime opening and endings on various streaming sites",
   "repository": "https://github.com/lexesjan/typescript-aniskip-extension",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "@headlessui/react": "^1.4.2",
     "@reduxjs/toolkit": "^1.7.1",
     "axios": "^0.24.0",
+    "entities": "^3.0.1",
     "glob-to-regexp": "^0.4.1",
     "lodash": "^4.17.21",
     "react": "^17.0.2",

--- a/src/components/SkipButton/SkipButton.tsx
+++ b/src/components/SkipButton/SkipButton.tsx
@@ -32,7 +32,7 @@ export function SkipButton({
       }`}
     >
       <DefaultButton
-        className={`transition-opacity font-sans whitespace-nowrap text-white bg-neutral-800 bg-opacity-80 py-3 border border-gray-300 font-bold uppercase hover:bg-opacity-100 ${
+        className={`transition-opacity font-sans whitespace-nowrap text-white bg-neutral-800 bg-opacity-80 py-3 border border-gray-300 font-bold uppercase hover:bg-opacity-100 backdrop-blur-md ${
           hidden ? 'opacity-0 pointer-events-none' : 'pointer-events-auto '
         }`}
         {...props}

--- a/src/components/SubmitMenu/SubmitMenu.tsx
+++ b/src/components/SubmitMenu/SubmitMenu.tsx
@@ -44,6 +44,7 @@ import {
   previewSkipTimeIntervalUpdated,
   selectPlayerControlsListenerType,
 } from '../../data';
+import { FRAME_RATE } from '../../players/base-player.types';
 
 export function SubmitMenu(): JSX.Element {
   const aniskipHttpClientRef = useRef<AniskipHttpClient>(
@@ -393,7 +394,7 @@ export function SubmitMenu(): JSX.Element {
     ) =>
     (event: React.WheelEvent<HTMLInputElement>): void => {
       const timeSeconds = timeStringToSeconds(currentTime);
-      const seekOffset = event.deltaY > 0 ? -0.01 : 0.01;
+      const seekOffset = event.deltaY > 0 ? -FRAME_RATE : FRAME_RATE;
       const updatedTime = errorCorrectTime(timeSeconds + seekOffset);
 
       setTime(secondsToTimeString(updatedTime));

--- a/src/components/SubmitMenu/SubmitMenu.tsx
+++ b/src/components/SubmitMenu/SubmitMenu.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../scripts/background';
 import {
   formatTimeString,
+  roundToClosestMultiple,
   secondsToTimeString,
   serialiseKeybind,
   timeStringToSeconds,
@@ -395,7 +396,9 @@ export function SubmitMenu(): JSX.Element {
     (event: React.WheelEvent<HTMLInputElement>): void => {
       const timeSeconds = timeStringToSeconds(currentTime);
       const seekOffset = event.deltaY > 0 ? -FRAME_RATE : FRAME_RATE;
-      const updatedTime = errorCorrectTime(timeSeconds + seekOffset);
+      const updatedTime = errorCorrectTime(
+        roundToClosestMultiple(timeSeconds + seekOffset, FRAME_RATE)
+      );
 
       setTime(secondsToTimeString(updatedTime));
 

--- a/src/pages/zoro/zoro.ts
+++ b/src/pages/zoro/zoro.ts
@@ -1,3 +1,4 @@
+import { decodeHTML } from 'entities';
 import { malIdUpdated, selectMalId } from '../../data';
 import { BasePage } from '../base-page';
 import { Metadata } from '../base-page.types';
@@ -14,7 +15,7 @@ export class Zoro extends BasePage {
   }
 
   getTitle(): string {
-    return this.getSyncData().name;
+    return decodeHTML(this.getSyncData().name);
   }
 
   getIdentifier(): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6753,6 +6753,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"entities@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "entities@npm:3.0.1"
+  checksum: aaf7f12033f0939be91f5161593f853f2da55866db55ccbf72f45430b8977e2b79dbd58c53d0fdd2d00bd7d313b75b0968d09f038df88e308aa97e39f9456572
+  languageName: node
+  linkType: hard
+
 "env-paths@npm:^2.2.0":
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
@@ -15155,6 +15162,7 @@ resolve@^2.0.0-next.3:
     cross-env: ^7.0.3
     css-loader: ^6.5.1
     css-minimizer-webpack-plugin: ^3.3.1
+    entities: ^3.0.1
     eslint: ^8.6.0
     eslint-config-airbnb: ^19.0.4
     eslint-config-airbnb-typescript: ^16.1.0


### PR DESCRIPTION
## Purpose

Titles are HTML encoded in zoro. We currently do not HTML decode the titles. 🤦‍♂️

Closes #122.

## Proposed Change

We need to HTML decode the title before searching for synonyms.

## Checklist

- [x] HTML decode the titles
- [x] Bump version patch

## Additional

Out of scope changes:

- [x] Change skip button to have background blur
- [x] Change mouse scrolling on the start time / end time to increase / decrease by one frame
